### PR TITLE
Ensure package imports resolve when running modules directly

### DIFF
--- a/app/backend/api.py
+++ b/app/backend/api.py
@@ -1,3 +1,11 @@
+import sys
+from pathlib import Path
+
+if __package__ is None or __package__ == "":
+    PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+    if str(PROJECT_ROOT) not in sys.path:
+        sys.path.insert(0, str(PROJECT_ROOT))
+
 from fastapi import FastAPI,HTTPException
 from pydantic import BaseModel
 from typing import List

--- a/app/frontend/ui.py
+++ b/app/frontend/ui.py
@@ -1,3 +1,11 @@
+import sys
+from pathlib import Path
+
+if __package__ is None or __package__ == "":
+    PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+    if str(PROJECT_ROOT) not in sys.path:
+        sys.path.insert(0, str(PROJECT_ROOT))
+
 import streamlit as st
 import requests
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,14 @@
+import sys
 import subprocess
 import threading
 import time
+from pathlib import Path
+
+if __package__ is None or __package__ == "":
+    PROJECT_ROOT = Path(__file__).resolve().parent.parent
+    if str(PROJECT_ROOT) not in sys.path:
+        sys.path.insert(0, str(PROJECT_ROOT))
+
 from dotenv import load_dotenv
 from app.common.logger import get_logger
 from app.common.custom_exception import CustomException


### PR DESCRIPTION
## Summary
- ensure backend, frontend, and orchestration entrypoints add the project root to sys.path when executed directly so package imports succeed

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68c8931a06e48320844825069ef7d8d5